### PR TITLE
Added query endpoint to API

### DIFF
--- a/app/src/main.py
+++ b/app/src/main.py
@@ -8,6 +8,7 @@ from src.config.logging import get_logger
 from src.config.settings import get_settings
 from src.dependencies import get_vector_store
 from src.routes import ingest_router
+from src.routes import query_router
 
 
 logger = get_logger(__name__)
@@ -51,6 +52,7 @@ def root():
 
 # Register routers
 app.include_router(ingest_router)
+app.include_router(query_router)
 
 @app.get("/health")
 def health_check():

--- a/app/src/routes/__init__.py
+++ b/app/src/routes/__init__.py
@@ -1,5 +1,6 @@
 """Routes package."""
 
 from src.routes.ingest import router as ingest_router
+from src.routes.query import router as query_router
 
-__all__ = ["ingest_router"]
+__all__ = ["ingest_router", "query_router"]

--- a/app/src/routes/query.py
+++ b/app/src/routes/query.py
@@ -1,0 +1,40 @@
+"""Query routes."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.config.logging import get_logger
+from src.dependencies import get_llm, get_rag_service
+from src.schemas.api import ModelInfoResponse, QueryRequest, QueryResponse
+from src.services.llm import LLMClient
+from src.services.rag import RAGService
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/query", tags=["query"])
+
+
+@router.post("", response_model=QueryResponse)
+def query(
+    request: QueryRequest,
+    rag_service: RAGService = Depends(get_rag_service),
+) -> QueryResponse:
+    """Query the RAG system with a question."""
+    logger.info(f"Query: {request.question[:50]}...")
+
+    try:
+        result = rag_service.query(
+            question=request.question,
+            filter_by_source=request.filter_by_source,
+        )
+        return QueryResponse(**result)
+    except Exception as e:
+        logger.error(f"Query failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/model", response_model=ModelInfoResponse)
+def get_model_info(
+    llm: LLMClient = Depends(get_llm),
+) -> ModelInfoResponse:
+    """Get current LLM model information."""
+    return ModelInfoResponse(**llm.get_model_info())

--- a/app/src/schemas/__init__.py
+++ b/app/src/schemas/__init__.py
@@ -1,1 +1,19 @@
-'''
+"""Schemas package."""
+
+from src.schemas.api import (
+    HealthResponse,
+    IngestResponse,
+    IngestStatsResponse,
+    ModelInfoResponse,
+    QueryRequest,
+    QueryResponse,
+)
+
+__all__ = [
+    "HealthResponse",
+    "IngestResponse",
+    "IngestStatsResponse",
+    "ModelInfoResponse",
+    "QueryRequest",
+    "QueryResponse",
+]

--- a/app/src/schemas/api.py
+++ b/app/src/schemas/api.py
@@ -1,0 +1,72 @@
+"""API request/response schemas."""
+
+from pydantic import BaseModel, Field
+
+
+# --- Query Schemas ---
+
+class QueryRequest(BaseModel):
+    """Request to query the RAG system."""
+
+    question: str = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Question to ask about product reviews",
+        examples=["What do users think about Google Wallet?"],
+    )
+    filter_by_source: bool = Field(
+        default=True,
+        description="Use LLM to pre-filter relevant apps",
+    )
+
+
+class QueryResponse(BaseModel):
+    """Response from RAG query."""
+
+    answer: str
+    sources: list[str]
+    num_docs: int
+    selected_sources: list[str] = []
+
+
+# --- Ingest Schemas ---
+
+class IngestResponse(BaseModel):
+    """Response from ingestion."""
+
+    success: bool
+    file: str
+    rows_loaded: int
+    chunks_added: int
+    collection_count: int
+
+
+class IngestStatsResponse(BaseModel):
+    """Response with ingestion statistics."""
+
+    total_documents: int
+    unique_categories: int
+    unique_apps: int
+    categories: list[str] | str
+
+
+# --- Health Schemas ---
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: str
+    service: str
+    documents: int
+
+
+# --- Model Info ---
+
+class ModelInfoResponse(BaseModel):
+    """LLM model information."""
+
+    provider: str
+    model: str
+    temperature: float
+    max_tokens: int


### PR DESCRIPTION
This pull request introduces a new query API to the application, enabling users to query the RAG (Retrieval-Augmented Generation) system and retrieve information about the underlying LLM model. It also refactors and expands the API schema definitions for better structure and clarity. The most important changes are grouped below:

**New Query API Endpoints:**

* Added a new `query_router` with two endpoints: a POST `/query` endpoint to handle RAG queries and a GET `/query/model` endpoint to return LLM model information.
* Registered the new `query_router` with the FastAPI application in `main.py`. [[1]](diffhunk://#diff-a75edaba70fb72fc7ff225c577f40fa0aa19dbd0d0d0fd418daa9c3d964d6a9aR11) [[2]](diffhunk://#diff-a75edaba70fb72fc7ff225c577f40fa0aa19dbd0d0d0fd418daa9c3d964d6a9aR55) [[3]](diffhunk://#diff-2b0f2750a516822451748721abe2898d7d249a2e5d8267846e62cb294d38f843R4-R6)

**API Schema Enhancements:**

* Created new Pydantic models in `schemas/api.py` for request and response validation, including `QueryRequest`, `QueryResponse`, `ModelInfoResponse`, `IngestResponse`, `IngestStatsResponse`, and `HealthResponse`.
* Updated the `schemas/__init__.py` to expose all relevant schema classes for import throughout the codebase.