### PR TITLE
Feature/dockerize streamlit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  web:
+    build:
+      context: ./web
+      args:
+        NEXT_PUBLIC_API_URL: http://localhost:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+
+  streamlit:
+    build: ./streamlit-app
+    ports:
+      - "8501:8501"
+    depends_on:
+      - api
+
   api:
     build: ./app
     ports:
@@ -7,6 +24,7 @@ services:
       - ./data:/app/data:ro
     env_file:
       - app/.env
+
   chromadb:
     image: chromadb/chroma:latest
     ports:

--- a/streamlit-app/.dockerignore
+++ b/streamlit-app/.dockerignore
@@ -1,0 +1,41 @@
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Streamlit
+.streamlit/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+*.md
+README*

--- a/streamlit-app/Dockerfile
+++ b/streamlit-app/Dockerfile
@@ -1,0 +1,25 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml .
+
+# Install dependencies
+RUN uv pip install --system --no-cache .
+
+# Copy application code
+COPY app.py .
+
+# Create non-root user
+RUN useradd --create-home appuser && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8501
+
+# Streamlit configuration
+ENV STREAMLIT_SERVER_PORT=8501
+ENV STREAMLIT_SERVER_ADDRESS=0.0.0.0
+ENV STREAMLIT_SERVER_HEADLESS=true
+
+CMD ["streamlit", "run", "app.py"]


### PR DESCRIPTION
This pull request introduces a new `streamlit` service to the project, enabling a Streamlit application to run alongside the existing services using Docker Compose. It also adds proper Docker configuration and ignores unnecessary files for the Streamlit app. The most important changes are grouped below:

**Docker Compose Service Additions:**

* Added a `streamlit` service to `docker-compose.yml`, building from `./streamlit-app`, exposing port 8501, and depending on the `api` service. This allows the Streamlit app to be run and accessed as part of the development environment.
* Added a `web` service to `docker-compose.yml`, building from `./web`, exposing port 3000, and depending on the `api` service.

**Streamlit App Dockerization:**

* Added a `Dockerfile` for the Streamlit app in `streamlit-app/`, using the `uv` Python base image, installing dependencies via `pyproject.toml`, setting up a non-root user, and configuring Streamlit to run on port 8501 in headless mode.
* Added a `.dockerignore` file in `streamlit-app/` to exclude Python cache files, IDE files, Git files, Docker files, OS files, Streamlit config, test outputs, and documentation from the Docker build context.